### PR TITLE
appinfo: add link to the website

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,8 +26,9 @@ Mac, with sync capabilities
     <category>office</category>
     <category>organization</category>
     <category>tools</category>
-    <screenshot>https://raw.githubusercontent.com/PhieF/CarnetDocumentation/master/intro/overview.png</screenshot>
-    <bugs>https://github.com/PhieF/CarnetNextcloud/issues</bugs>
+    <screenshot>https://raw.githubusercontent.com/CarnetApp/CarnetDocumentation/master/intro/overview.png</screenshot>
+    <bugs>https://github.com/CarnetApp/CarnetNextcloud/issues</bugs>
+    <website>https://github.com/CarnetApp/CarnetNextcloud</website>
     <types>
             <filesystem/>
     </types>


### PR DESCRIPTION
First, thank you for this useful Nextcloud app!

This is a detail but it is useful to get a link to this repo, e.g. to check the ChangeLog (last commits), the code, etc.

We can see this link from https://apps.nextcloud.com/apps/carnet but also in Nextcloud settings.

Note: I also updated the bugs and screenshot entries to use the files from CarnetApp account instead of the former PhieF one.