### PR TITLE
Do not generate logs when the user try to remove/move untitleddonoted…

### DIFF
--- a/lib/Controller/NoteController.php
+++ b/lib/Controller/NoteController.php
@@ -653,9 +653,11 @@ public function getOpusEncoder(){
       * @NoAdminRequired
       * @NoCSRFRequired
       */
-	 public function deleteNote($path){
-		$this->CarnetFolder->get($path)->delete();
-     }
+      public function deleteNote($path){
+          if ($path === "untitleddonotedit.sqd")
+              return;
+          $this->CarnetFolder->get($path)->delete();
+      }
 
      /**
       * @NoAdminRequired
@@ -665,6 +667,8 @@ public function getOpusEncoder(){
         if($this->CarnetFolder->nodeExists($to)){
             throw new Exception("Already exists");
         }
+       if ($from === "untitleddonotedit.sqd")
+           return;
        $this->CarnetFolder->get($from)->move($this->CarnetFolder->getFullPath($to));
        $actions = array();
        $actions[0] = array();


### PR DESCRIPTION
When the user start, the untitleddonotedit cards are displayed. The user try immediately to remove/edit them, even if it is impossible.
The system try to open the file in local, it doesn't exists and a log is generated.
With the patch, no log is generated for the untitleddonotedit cards edition.
