### PR TITLE
search : do not generate PHP logs in standard usage

### DIFF
--- a/lib/Misc/Search.php
+++ b/lib/Misc/Search.php
@@ -149,7 +149,7 @@ private function search($relativePath, $folder, $query, $curDepth){
                 } catch(Exception $e){
                 }
                 $index = $zipFile->getEntryContents("index.html");
-                if(strstr(strtolower($this->removeAccents($index)), $query)){
+                if(trim ($query) !== "" && strstr(strtolower($this->removeAccents($index)), $query)){
                     $this->writeFound($relativePath,$in);
                 }
             } catch(\OCP\Files\NotFoundException $e) {

--- a/lib/Misc/Search.php
+++ b/lib/Misc/Search.php
@@ -17,6 +17,7 @@ class Search {
     private $searchCache;
     private $current=0;
     private $from;
+    private $pathArray = array ();
 
     /**
          * @param string $appName

--- a/lib/Misc/Search.php
+++ b/lib/Misc/Search.php
@@ -132,11 +132,14 @@ private function search($relativePath, $folder, $query, $curDepth){
                 try {
                     $metadata = json_decode($zipFile->getEntryContents("metadata.json"));
                     $hasFound = false;
-                    foreach($metadata->keywords as $keyword){
-                        if(strstr($this->removeAccents(strtolower($keyword)), $query)){
-                            $this->writeFound($relativePath,$in);
-                            $hasFound = true;
-                            break;
+                    if (is_object ($metadata))
+                    {
+                        foreach($metadata->keywords as $keyword){
+                            if(strstr($this->removeAccents(strtolower($keyword)), $query)){
+                                $this->writeFound($relativePath,$in);
+                                $hasFound = true;
+                                break;
+                            }
                         }
                     }
                     if($hasFound){


### PR DESCRIPTION
When the user start, the untitleddonotedit cards are displayed. The user try immediately to search, some logs are generated