### PR TITLE
Patch log using

### DIFF
--- a/lib/Controller/NoteController.php
+++ b/lib/Controller/NoteController.php
@@ -998,7 +998,9 @@ public function getOpusEncoder(){
             }
             
             $file->putContent($tmph);
-            fclose($tmph);
+            // Do not close $tmph, it is closed by putContent, and a log is displayed as
+            // fclose can not work
+            //fclose($tmph);
             $meta['metadata'] = json_decode($folder->get("metadata.json")->getContent());
             $meta['shorttext'] = NoteUtils::getShortTextFromHTML($folder->get("index.html")->getContent());
             $cache = new CacheManager($this->db, $this->CarnetFolder);

--- a/lib/Misc/CacheManager.php
+++ b/lib/Misc/CacheManager.php
@@ -95,7 +95,8 @@ class CacheManager{
     public function deleteFromCache($relativePath){
         $sql = 'DELETE FROM `*PREFIX*carnet_metadata` WHERE `path` = ?';
         $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(1, $this->carnetFolder->getFullPath($relativePath), \PDO::PARAM_STR);
+        $param = $this->carnetFolder->getFullPath($relativePath);
+        $stmt->bindParam(1, $param, \PDO::PARAM_STR);
         $stmt->execute();
 
     }


### PR DESCRIPTION
In basic usage, there is a lot of error logs generated by carnet. Each time a text is saved, 2 logs are displayed :
- Only variables should be passed by reference at lib/Misc/CacheManager.php#98
- fclose(): supplied resource is not a valid stream resource at lib/Controller/NoteController.php#1001

This patch allow to solve these problems