### PR TITLE
Path length in database needs to be higher

### DIFF
--- a/lib/Migration/Version002401Date20210711195249.php
+++ b/lib/Migration/Version002401Date20210711195249.php
@@ -36,7 +36,7 @@ class Version002401Date20210711195249 extends SimpleMigrationStep {
 			$table = $schema->createTable('carnet_metadata');
 			$table->addColumn('path', 'string', [
 				'notnull' => true,
-				'length' => 191,
+				'length' => 300,
 			]);
 			$table->addColumn('metadata', 'string', [
 				'notnull' => false,


### PR DESCRIPTION
Some of the users on my server had used paths longer than 191 characters, and this breaks the cache rebuild process.


Server output:

Server# sudo -u www-data php occ carnet:cache rebuild
*list of user files*
/username/files/Documents/QuickNote/companyname/Á###á####/#######ó á###á######/500- 700 #á#á### #####é#  6 ##á###é#. #ö###á# #6 #7 ##########á# #ö#######á#. #ő#### #######é## 800 1000 ####### ####á## ##á##ő##é# ####á# .sqd (the problematic file, private information blanked out)


In ExceptionConverter.php line 114:
An exception occurred while executing a query: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'path' at row 1  
                                                                                                                                               
In Exception.php line 26:
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'path' at row 1  

In Statement.php line 82:
[22001]: String data, right truncated: 1406 Data too long for column 'path' at row 1  
                                                                                                
