### PR TITLE
Fix runtime error in NextCloud 20.0.11

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -53,7 +53,7 @@ class Application extends App {
             });
     }
 }
-$app = new Application();
+$app = \OC::$server->query(Application::class);
 $container = $app->getContainer();
 
 $app->connectWatcher($container);


### PR DESCRIPTION
The following runtime error was filling up my logs:

{"reqId":"YUDKZYoHi89sQ2v4nuD6ewAAAQ0","level":3,"time":"2021-09-14T18:14:29+02:00","remoteAddr":"xxx.yyy.zzz.aaa","user":"admin","app":"carnet","method":"GET","url":"/ocs/v2.php/apps/notifications/api/v2/notifications","message":{"Exception":"RuntimeException","Message":"App class OCA\\Carnet\\AppInfo\\Application is 
not setup via query() but directly","Code":0,"Trace":[{"file":"/var/www/nextcloud/apps/carnet/appinfo/app.php","line":19,"function":"__construct","class":"OCP\\AppFramework\\App","type":"->","args":["carnet",[]]},{"file":"/var/www/nextcloud/apps/carnet/appinfo/app.php","line":56,"function":"__construct","class":"OCA
\\Carnet\\AppInfo\\Application","type":"->","args":[]},{"file":"/var/www/nextcloud/lib/private/legacy/OC_App.php","line":297,"args":["/var/www/nextcloud/apps/carnet/appinfo/app.php"],"function":"require_once"},{"file":"/var/www/nextcloud/lib/private/legacy/OC_App.php","line":179,"function":"requireAppFile","class":"
OC_App","type":"::","args":["carnet"]},{"file":"/var/www/nextcloud/lib/private/legacy/OC_App.php","line":132,"function":"loadApp","class":"OC_App","type":"::","args":["carnet"]},{"file":"/var/www/nextcloud/ocs/v1.php","line":56,"function":"loadApps","class":"OC_App","type":"::","args":[]},{"file":"/var/www/nextcloud
/ocs/v2.php","line":24,"args":["/var/www/nextcloud/ocs/v1.php"],"function":"require_once"}],"File":"/var/www/nextcloud/lib/public/AppFramework/App.php","Line":85,"CustomMessage":"--"},"userAgent":"Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0","version":"20.0.11.1"}

I found nextcloud/calendar#1958 which seems to solve this  for Calendar, so I propsose the same solution here.