### PR TITLE
Check for existence of 'text' key in $metadata

### DIFF
--- a/lib/Controller/NoteController.php
+++ b/lib/Controller/NoteController.php
@@ -643,7 +643,7 @@ public function getOpusEncoder(){
                     try{
                         $meta = $utils->getMetadata($this->CarnetFolder, $path);
                         $array[$path] = $meta;
-                        $cache->addToCache($path, $meta, $meta['lastmodfile'], $meta['text']);
+                        $cache->addToCache($path, $meta, $meta['lastmodfile'], isset($meta['text']) ? $meta['text'] : '');
                     } catch(\PhpZip\Exception\ZipException $e){
 
                     }

--- a/lib/Hooks/FSHooks.php
+++ b/lib/Hooks/FSHooks.php
@@ -82,7 +82,7 @@ class FSHooks {
                 $cacheManager = new CacheManager($this->db, $this->carnetFolder);
                 $utils = new NoteUtils();
                 $metadata = $utils->getMetadata($this->carnetFolder, $relativePath);
-                $cacheManager->addToCache($relativePath, $metadata, $metadata['lastmodfile'], $metadata['text']);
+                $cacheManager->addToCache($relativePath, $metadata, $metadata['lastmodfile'], isset($metadata['text']) ? $metadata['text'] : '');
             } catch(\PhpZip\Exception\ZipException $e){
 
             }


### PR DESCRIPTION
Adds a check for the 'text' key of the `$metadata` variable before using it.
This could be done as a null coalesce, but I'm unsure what the minimum supported PHP version is.

Fixes #191
