### PR TITLE
Fix Nextcloud 33/34 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.25.14
+
+Fix Nextcloud 33/34 compatibility (removed OC\Server deprecated methods)
+
 # Version 0.25.13
 
 Fix AppInfo deprecated (@presslab-us)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ Mac, with sync capabilities
 - Statistics : words/sentences/characters
 - Sync with ownCloud/NextCloud
 - Online editor as a ownCloud/NextCloud App]]></description>
-    <version>0.25.13</version>
+    <version>0.25.14</version>
     <licence>agpl</licence>
     <author mail="phie@phie.ovh" >Phie</author>
     <namespace>Carnet</namespace>
@@ -33,7 +33,7 @@ Mac, with sync capabilities
             <filesystem/>
     </types>
     <dependencies>
-         <nextcloud min-version="13" max-version="32"/>
+         <nextcloud min-version="13" max-version="34"/>
          <owncloud min-version="10" max-version="10"/>
 
     </dependencies>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,7 +8,10 @@ use OCP\Files\IRootFolder;
 use OCP\Files\Node;
 use OCP\AppFramework\IAppContainer;
 use OCP\Util;
+use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\IUserSession;
 
 if ((@include_once __DIR__ . '/../../vendor/autoload.php')===false) {
 	throw new \Exception('Cannot include autoload. Did you run install dependencies using composer?');
@@ -20,15 +23,15 @@ class Application extends App {
         $container = $this->getContainer();
         $container->registerService('Config', function($c) {
 
-            return $c->query('ServerContainer')->getConfig();
+            return $c->get(IConfig::class);
         });
 
         $container->registerService('RootFolder', function($c) {
 
-            return $c->query('ServerContainer')->getRootFolder();
+            return $c->get(IRootFolder::class);
         });
         $container->registerService('UserManager', function($c) {
-            return $c->query('ServerContainer')->getUserManager();
+            return $c->get(IUserManager::class);
         });
     }
 
@@ -36,18 +39,16 @@ class Application extends App {
             /** @var IRootFolder $root */
             $root = $container->query(IRootFolder::class);
             $root->listen('\OC\Files', 'postWrite', function (Node $node) use ($container) {
-                $c = $container->query('ServerContainer'); 
-                $user = $c->getUserSession()->getUser();
+                $user = $container->get(IUserSession::class)->getUser();
                 if($user != null){
-                    $watcher = new FSHooks($c->getUserFolder(), $user->getUID(), $c->getConfig(), 'carnet',$container->query(IDBConnection::class));
+                    $watcher = new FSHooks($container->get(IRootFolder::class)->getUserFolder($user->getUID()), $user->getUID(), $container->get(IConfig::class), 'carnet',$container->query(IDBConnection::class));
                     $watcher->postWrite($node);
                  }
             });
             $root->listen('\OC\Files', 'postDelete', function (Node $node) use ($container) {
-                $c = $container->query('ServerContainer');
-                $user = $c->getUserSession()->getUser();
+                $user = $container->get(IUserSession::class)->getUser();
                 if($user != null){
-                    $watcher = new FSHooks($c->getUserFolder(), $user->getUID(), $c->getConfig(), 'carnet',$container->query(IDBConnection::class));
+                    $watcher = new FSHooks($container->get(IRootFolder::class)->getUserFolder($user->getUID()), $user->getUID(), $container->get(IConfig::class), 'carnet',$container->query(IDBConnection::class));
                     $watcher->postDelete($node);
                  }
             });

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -26,44 +26,43 @@ namespace OCA\Carnet\Settings;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
-if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
-	class AdminSettings implements ISettings {
 
-		/** @var IConfig */
-		private $config;
+class AdminSettings implements ISettings {
 
-		/**
-		 * AdminSettings constructor.
-		 *
-		 * @param IConfig $config
-		 */
-		public function __construct(IConfig $config) {
-			$this->config = $config;
-		}
+	/** @var IConfig */
+	private $config;
 
-		/**
-		 * @return TemplateResponse
-		 */
-		public function getForm() {
-			$parameters = [
-				'carnet_display_fullscreen' => $this->config->getAppValue('carnet', 'carnetDisplayFullscreen', 'no'),
-			];
+	/**
+	 * AdminSettings constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
 
-			return new TemplateResponse('carnet', 'settings/settings-admin', $parameters);
-		}
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		$parameters = [
+			'carnet_display_fullscreen' => $this->config->getAppValue('carnet', 'carnetDisplayFullscreen', 'no'),
+		];
 
-		/**
-		 * @return string
-		 */
-		public function getSection() {
-			return 'additional';
-		}
+		return new TemplateResponse('carnet', 'settings/settings-admin', $parameters);
+	}
 
-		/**
-		 * @return int
-		 */
-		public function getPriority() {
-			return 20;
-		}
+	/**
+	 * @return string
+	 */
+	public function getSection() {
+		return 'additional';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPriority() {
+		return 20;
 	}
 }

--- a/templates/browser.php
+++ b/templates/browser.php
@@ -50,6 +50,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 else{
     style("carnet","../templates/CarnetElectron/compatibility/nextcloud/owncloud");
 }

--- a/templates/exporter.php
+++ b/templates/exporter.php
@@ -32,12 +32,18 @@ $file .= "<script src=\"".$root."/CarnetElectron/compatibility/nextcloud/fullscr
 
 $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
-$urlGenerator = \OC::$server->getURLGenerator();
+$urlGenerator = method_exists(\OC::$server, 'getURLGenerator') ? \OC::$server->getURLGenerator() : \OCP\Server::get(\OCP\IURLGenerator::class);
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
-    $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+else{
+    $nonce = "";
+}
+$file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);
 echo $file;
 

--- a/templates/importer.php
+++ b/templates/importer.php
@@ -32,12 +32,18 @@ $file .= "<script src=\"".$root."/CarnetElectron/compatibility/nextcloud/fullscr
 
 $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
-$urlGenerator = \OC::$server->getURLGenerator();
+$urlGenerator = method_exists(\OC::$server, 'getURLGenerator') ? \OC::$server->getURLGenerator() : \OCP\Server::get(\OCP\IURLGenerator::class);
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
-    $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+else{
+    $nonce = "";
+}
+$file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);
 echo $file;
 

--- a/templates/new_browser.php
+++ b/templates/new_browser.php
@@ -50,6 +50,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 else{
     style("carnet","../templates/CarnetWebClient/compatibility/nextcloud/owncloud");
 }

--- a/templates/new_editor.php
+++ b/templates/new_editor.php
@@ -31,12 +31,18 @@ $file .= "<span style=\"display:none;\" id=\"token\">".$_['requesttoken']."</spa
 
 $file = str_replace("<!ROOTPATH>", $root."/CarnetWebClient/", $file);
 //$root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
-$urlGenerator = \OC::$server->getURLGenerator();
+$urlGenerator = method_exists(\OC::$server, 'getURLGenerator') ? \OC::$server->getURLGenerator() : \OCP\Server::get(\OCP\IURLGenerator::class);
 $file = str_replace("<!ROOTURL>", $root."/CarnetWebClient/", $file);
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
-    $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+else{
+    $nonce = "";
+}
+$file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);
 echo $file;
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -31,6 +31,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"".$root."/CarnetWebClient/",$file);
 echo $file;
 echo "<span style=\"display:none;\" id=\"root-url\">".$root."/CarnetWebClient/</span>";

--- a/templates/writer.php
+++ b/templates/writer.php
@@ -32,12 +32,18 @@ $file .= "<script src=\"".$root."/CarnetElectron/compatibility/nextcloud/fullscr
 
 $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
-$urlGenerator = \OC::$server->getURLGenerator();
+$urlGenerator = method_exists(\OC::$server, 'getURLGenerator') ? \OC::$server->getURLGenerator() : \OCP\Server::get(\OCP\IURLGenerator::class);
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
-    $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
+else if (class_exists('\OCP\Server') && class_exists('\OC\Security\CSP\ContentSecurityPolicyNonceManager')){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+else{
+    $nonce = "";
+}
+$file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);
 echo $file;
 


### PR DESCRIPTION
Note: This PR was AI-assisted. I used opencode with Qwen 3.6 27B and Kimi K3, with Kimi K3 doing the code writing.

Fixes #238, refs #239.

Nextcloud 34 removed the long-deprecated `OC\Server` getter methods (`getRootFolder`, `getConfig`, `getUserManager`, `getURLGenerator`, `getContentSecurityPolicyNonceManager`, ...), deprecated since before Nextcloud 20. On NC 34.0.0 this makes Carnet fail with e.g.:

```
Call to undefined method OC\Server::getRootFolder()
```

when running `occ update:check`, and breaks several app pages that call `\OC::$server->getURLGenerator()`.

### Changes

- **lib/AppInfo/Application.php**: resolve services via `IContainer::get()` with the corresponding OCP interfaces (`IConfig`, `IRootFolder`, `IUserManager`, `IUserSession`) instead of the removed `ServerContainer` getters. The app container falls back to the server container for `OCP\\`/`OC\\` service names, so this keeps working on older versions too.
- **templates** (writer, new_editor, importer, exporter, new_browser, browser, settings): fall back to `\OCP\Server::get(\OCP\IURLGenerator::class)` and `\OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)` (the same call core uses in `lib/private/Template/functions.php`) when the legacy getters are gone, guarded by `method_exists`/`class_exists` so older Nextcloud and ownCloud keep working unchanged.
- **lib/Settings/AdminSettings.php**: the whole class declaration was wrapped in `method_exists(\OC::$server, 'getContentSecurityPolicyNonceManager')`, which means the class would not exist at all on NC34 (breaking admin settings registration). It is now defined unconditionally.
- **appinfo/info.xml**: raise `max-version` to 34, bump version to 0.25.14 with a CHANGELOG entry.

All edited files pass `php -l`, and every API used was verified against the `nextcloud/server` stable34 sources (including that the legacy `\OC\Files` postWrite/postDelete hooks are still emitted by `HookConnector`).