### PR TITLE
Nextcloud 34 compatibility 

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ Mac, with sync capabilities
             <filesystem/>
     </types>
     <dependencies>
-         <nextcloud min-version="13" max-version="32"/>
+         <nextcloud min-version="13" max-version="34"/>
          <owncloud min-version="10" max-version="10"/>
 
     </dependencies>

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -26,44 +26,43 @@ namespace OCA\Carnet\Settings;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
-if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
-	class AdminSettings implements ISettings {
 
-		/** @var IConfig */
-		private $config;
+class AdminSettings implements ISettings {
 
-		/**
-		 * AdminSettings constructor.
-		 *
-		 * @param IConfig $config
-		 */
-		public function __construct(IConfig $config) {
-			$this->config = $config;
-		}
+	/** @var IConfig */
+	private $config;
 
-		/**
-		 * @return TemplateResponse
-		 */
-		public function getForm() {
-			$parameters = [
-				'carnet_display_fullscreen' => $this->config->getAppValue('carnet', 'carnetDisplayFullscreen', 'no'),
-			];
+	/**
+	 * AdminSettings constructor.
+	 *
+	 * @param IConfig $config
+	 */
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
 
-			return new TemplateResponse('carnet', 'settings/settings-admin', $parameters);
-		}
+	/**
+	 * @return TemplateResponse
+	 */
+	public function getForm() {
+		$parameters = [
+			'carnet_display_fullscreen' => $this->config->getAppValue('carnet', 'carnetDisplayFullscreen', 'no'),
+		];
 
-		/**
-		 * @return string
-		 */
-		public function getSection() {
-			return 'additional';
-		}
+		return new TemplateResponse('carnet', 'settings/settings-admin', $parameters);
+	}
 
-		/**
-		 * @return int
-		 */
-		public function getPriority() {
-			return 20;
-		}
+	/**
+	 * @return string
+	 */
+	public function getSection() {
+		return 'additional';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPriority() {
+		return 20;
 	}
 }

--- a/templates/browser.php
+++ b/templates/browser.php
@@ -50,6 +50,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 else{
     style("carnet","../templates/CarnetElectron/compatibility/nextcloud/owncloud");
 }

--- a/templates/exporter.php
+++ b/templates/exporter.php
@@ -34,8 +34,14 @@ $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
 $urlGenerator = \OC::$server->getURLGenerator();
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
+$nonce = null;
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+if ($nonce !== null){
     $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);

--- a/templates/importer.php
+++ b/templates/importer.php
@@ -34,8 +34,14 @@ $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
 $urlGenerator = \OC::$server->getURLGenerator();
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
+$nonce = null;
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+if ($nonce !== null){
     $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);

--- a/templates/new_browser.php
+++ b/templates/new_browser.php
@@ -50,6 +50,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 else{
     style("carnet","../templates/CarnetWebClient/compatibility/nextcloud/owncloud");
 }

--- a/templates/new_editor.php
+++ b/templates/new_editor.php
@@ -33,8 +33,14 @@ $file = str_replace("<!ROOTPATH>", $root."/CarnetWebClient/", $file);
 //$root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
 $urlGenerator = \OC::$server->getURLGenerator();
 $file = str_replace("<!ROOTURL>", $root."/CarnetWebClient/", $file);
+$nonce = null;
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+if ($nonce !== null){
     $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -31,6 +31,9 @@ $nonce = "";
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 }
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
 $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"".$root."/CarnetWebClient/",$file);
 echo $file;
 echo "<span style=\"display:none;\" id=\"root-url\">".$root."/CarnetWebClient/</span>";

--- a/templates/writer.php
+++ b/templates/writer.php
@@ -34,8 +34,14 @@ $file = str_replace("<!ROOTPATH>", $root."/CarnetElectron/", $file);
 $root = substr(__DIR__, strlen($_SERVER['DOCUMENT_ROOT']));
 $urlGenerator = \OC::$server->getURLGenerator();
 $file = str_replace("<!ROOTURL>", $root."/CarnetElectron/", $file);
+$nonce = null;
 if (method_exists(\OC::$server, "getContentSecurityPolicyNonceManager")){
     $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
+elseif (class_exists(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)){
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+}
+if ($nonce !== null){
     $file = str_replace("src=\"","defer nonce='".$nonce."' src=\"",$file);
 }
 $file = str_replace("<!APIURL>", parse_url($urlGenerator->linkToRouteAbsolute("carnet.page.index"), PHP_URL_PATH), $file);


### PR DESCRIPTION
- Bump max-version to 34 in info.xml
- Always declare AdminSettings (drop legacy method_exists wrapper)
- Add CSP nonce fallback via Server::get(ContentSecurityPolicyNonceManager) in all templates so inline scripts get a nonce on NC 28+.
(made with AI, possible errors in the code, but works for now)